### PR TITLE
[#9] Set assoc=true in json_decode call

### DIFF
--- a/src/DataFeed/Cache/FileGetContentsFeedCache.php
+++ b/src/DataFeed/Cache/FileGetContentsFeedCache.php
@@ -64,7 +64,7 @@ class FileGetContentsFeedCache implements FeedCache
 
 		$contents = file_get_contents( $u );
 
-		$data = \json_decode( $contents );
+		$data = \json_decode( $contents, true );
 
 		if ( $data === null ) {
 			throw new FeedCacheException( 'The current data item in data feed ' . $feedName . ' could not be parsed.' );


### PR DESCRIPTION
of FileGetContentsFeedCache->getCurrentItem to get an associative array back. @AndreasJonsson could you please code check this and add a test for this bugfix (given that the fix is any good :wink:)
